### PR TITLE
Adding email prefill if query string value is present

### DIFF
--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Controllers/AccountController.cs
@@ -197,9 +197,10 @@ namespace DevAdventCalendarCompetition.Controllers
 
         [HttpGet]
         [AllowAnonymous]
-        public IActionResult Register(string returnUrl = null)
+        public IActionResult Register(string returnUrl = null, string email = null)
         {
             ViewData["ReturnUrl"] = returnUrl;
+            ViewData["Email"] = email;
             return View();
         }
 

--- a/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Account/Register.cshtml
+++ b/src/DevAdventCalendarCompetition/DevAdventCalendarCompetition/Views/Account/Register.cshtml
@@ -10,7 +10,7 @@
             <div asp-validation-summary="All" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Email">Email</label>
-                <input asp-for="Email" class="form-control" />
+                <input asp-for="Email" class="form-control" value="@ViewData["Email"]" />
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
             <div class="form-group">


### PR DESCRIPTION
To improve the registration conversion all the users receiving an invitation to register should get a link that contains a query string with their email used to prefill the form with their email address so that they don't have to fill it in.

## Where should the reviewer start?
This is a small change so just check the changed code.

## How has this been tested?
Scenarios tested:
- email is present in the query string 
```
?email=test@test.com
```
- email not present in the query string
- email encoded 
```
?email=test%40test.com
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)